### PR TITLE
Toggle CRESET on jtag reset

### DIFF
--- a/firmware/pico-dirtyJtag/dirtyJtag.c
+++ b/firmware/pico-dirtyJtag/dirtyJtag.c
@@ -3,6 +3,7 @@
 #include "pico/binary_info.h"
 #include "hardware/pio.h"
 #include "pico/multicore.h"
+#include "dirtyJtagConfig.h"
 #include "pio_jtag.h"
 #include "bsp/board.h"
 #include "tusb.h"
@@ -12,7 +13,8 @@
 #include "hardware/structs/pll.h"
 #include "hardware/structs/clocks.h"
 
-#include "dirtyJtagConfig.h"
+#include "led.h"
+#include "cdc_uart.h"
 
 #define MULTICORE
 

--- a/firmware/pico-dirtyJtag/pio_jtag.c
+++ b/firmware/pico-dirtyJtag/pio_jtag.c
@@ -1,5 +1,6 @@
 #include <hardware/clocks.h>
 #include "hardware/dma.h"
+#include "dirtyJtagConfig.h"
 #include "pio_jtag.h"
 #include "jtag.pio.h"
 

--- a/firmware/pico-dirtyJtag/pio_jtag.h
+++ b/firmware/pico-dirtyJtag/pio_jtag.h
@@ -2,6 +2,7 @@
 #ifndef _PIO_JTAG_H
 #define _PIO_JTAG_H
 
+#include "pico/stdlib.h"
 #include "hardware/pio.h"
 
 typedef struct pio_jtag_inst {
@@ -37,8 +38,10 @@ static inline void jtag_set_tms(const pio_jtag_inst_t *jtag, bool value)
 }
 static inline void jtag_set_rst(const pio_jtag_inst_t *jtag, bool value)
 {
-    /* Change the direction to out to drive pin to 0 or to in to emulate open drain */
-    gpio_set_dir(jtag->pin_rst, !value);
+    // toggle CRESET
+    gpio_put(PIN_CRESET, 0);
+    sleep_ms(250);
+    gpio_put(PIN_CRESET, 1);
 }
 static inline void jtag_set_trst(const pio_jtag_inst_t *jtag, bool value)
 {


### PR DESCRIPTION
This fixes updating with new bitstream, so it is not needed any more to re-plug USB when updating it.
Also fixed some compiler warnings/errors with new one (required missing headers)

It requires openFPGALoader after https://github.com/trabucayre/openFPGALoader/commit/3cf558ebe2f878bd598e883d2f7783363efdb172 change